### PR TITLE
Display RPS/throughput as float64 instead of integer

### DIFF
--- a/gobench.go
+++ b/gobench.go
@@ -109,21 +109,17 @@ func printResults(results map[int]*Result, startTime time.Time) {
 		writeThroughput += result.writeThroughput
 	}
 
-	elapsed := int64(time.Since(startTime).Seconds())
-
-	if elapsed == 0 {
-		elapsed = 1
-	}
+	elapsed := time.Since(startTime).Seconds()
 
 	fmt.Println()
-	fmt.Printf("Requests:                       %10d hits\n", requests)
-	fmt.Printf("Successful requests:            %10d hits\n", success)
-	fmt.Printf("Network failed:                 %10d hits\n", networkFailed)
-	fmt.Printf("Bad requests failed (!2xx):     %10d hits\n", badFailed)
-	fmt.Printf("Successfull requests rate:      %10d hits/sec\n", success/elapsed)
-	fmt.Printf("Read throughput:                %10d bytes/sec\n", readThroughput/elapsed)
-	fmt.Printf("Write throughput:               %10d bytes/sec\n", writeThroughput/elapsed)
-	fmt.Printf("Test time:                      %10d sec\n", elapsed)
+	fmt.Printf("Requests:                       %13d hits\n", requests)
+	fmt.Printf("Successful requests:            %13d hits\n", success)
+	fmt.Printf("Network failed:                 %13d hits\n", networkFailed)
+	fmt.Printf("Bad requests failed (!2xx):     %13d hits\n", badFailed)
+	fmt.Printf("Successfull requests rate:      %13.2f hits/sec\n", float64(success)/elapsed)
+	fmt.Printf("Read throughput:                %13.2f bytes/sec\n", float64(readThroughput)/elapsed)
+	fmt.Printf("Write throughput:               %13.2f bytes/sec\n", float64(writeThroughput)/elapsed)
+	fmt.Printf("Test time:                      %13.2f sec\n", elapsed)
 }
 
 func readLines(path string) (lines []string, err error) {

--- a/gobench.go
+++ b/gobench.go
@@ -245,9 +245,9 @@ func MyClient(result *Result, connectTimeout, readTimeout, writeTimeout time.Dur
 
 	return &http.Client{
 		Transport: &http.Transport{
-			Dial:            	TimeoutDialer(result, connectTimeout, readTimeout, writeTimeout),
-			TLSClientConfig: 	&tls.Config{InsecureSkipVerify: true},
-			DisableKeepAlives: 	!keepAlive,
+			Dial:              TimeoutDialer(result, connectTimeout, readTimeout, writeTimeout),
+			TLSClientConfig:   &tls.Config{InsecureSkipVerify: true},
+			DisableKeepAlives: !keepAlive,
 		},
 	}
 }


### PR DESCRIPTION
In high throughput low elapsed time situation, the request rate accuracy is very low.

For example,

```
$ ./gobench -c=1000 -r=10 -tc=10000 -tr=10000 -tw=10000 -u="<SAMPLE URL>"
Dispatching 1000 clients
Waiting for results...

Requests:                            10000 hits
Successful requests:                 10000 hits
Network failed:                          0 hits
Bad requests failed (!2xx):              0 hits
Successfull requests rate:            5000 hits/sec
Read throughput:                  24880000 bytes/sec
Write throughput:                   720000 bytes/sec
Test time:                               2 sec

$ ./gobench -c=1000 -r=10 -tc=10000 -tr=10000 -tw=10000 -u="<SAMPLE URL>"
Dispatching 1000 clients
Waiting for results...

Requests:                            10000 hits
Successful requests:                 10000 hits
Network failed:                          0 hits
Bad requests failed (!2xx):              0 hits
Successfull requests rate:            3333 hits/sec
Read throughput:                  16586666 bytes/sec
Write throughput:                   480000 bytes/sec
Test time:                               3 sec
```

This patch shows RPS/throughput as float instead of integer.