### PR TITLE
Support `Authorization` header and configurable success status codes

### DIFF
--- a/gobench.go
+++ b/gobench.go
@@ -29,15 +29,17 @@ var (
 	connectTimeout   int
 	writeTimeout     int
 	readTimeout      int
+	authHeader       string
 )
 
 type Configuration struct {
-	urls      []string
-	method    string
-	postData  []byte
-	requests  int64
-	period    int64
-	keepAlive bool
+	urls       []string
+	method     string
+	postData   []byte
+	requests   int64
+	period     int64
+	keepAlive  bool
+	authHeader string
 }
 
 type Result struct {
@@ -89,6 +91,7 @@ func init() {
 	flag.IntVar(&connectTimeout, "tc", 5000, "Connect timeout (in milliseconds)")
 	flag.IntVar(&writeTimeout, "tw", 5000, "Write timeout (in milliseconds)")
 	flag.IntVar(&readTimeout, "tr", 5000, "Read timeout (in milliseconds)")
+	flag.StringVar(&authHeader, "auth", "", "Authorization header")
 }
 
 func printResults(results map[int]*Result, startTime time.Time) {
@@ -174,11 +177,12 @@ func NewConfiguration() *Configuration {
 	}
 
 	configuration := &Configuration{
-		urls:      make([]string, 0),
-		method:    "GET",
-		postData:  nil,
-		keepAlive: keepAlive,
-		requests:  int64((1 << 63) - 1)}
+		urls:       make([]string, 0),
+		method:     "GET",
+		postData:   nil,
+		keepAlive:  keepAlive,
+		requests:   int64((1 << 63) - 1),
+		authHeader: authHeader}
 
 	if period != -1 {
 		configuration.period = period
@@ -281,6 +285,10 @@ func client(configuration *Configuration, result *Result, done *sync.WaitGroup) 
 				req.Header.Add("Connection", "keep-alive")
 			} else {
 				req.Header.Add("Connection", "close")
+			}
+
+			if len(configuration.authHeader) > 0 {
+				req.Header.Add("Authorization", configuration.authHeader)
 			}
 
 			resp, err := myclient.Do(req)


### PR DESCRIPTION
Adds a `-auth` flag for setting `Authorization` header