### PR TITLE
respect http_proxy environment var

### DIFF
--- a/gobench.go
+++ b/gobench.go
@@ -257,6 +257,7 @@ func MyClient(result *Result, connectTimeout, readTimeout, writeTimeout time.Dur
 			Dial:              TimeoutDialer(result, connectTimeout, readTimeout, writeTimeout),
 			TLSClientConfig:   &tls.Config{InsecureSkipVerify: true},
 			DisableKeepAlives: !keepAlive,
+			Proxy:             http.ProxyFromEnvironment,
 		},
 	}
 }


### PR DESCRIPTION
HTTP_PROXY, HTTPS_PROXY, and NOPROXY environment variables should be used when set. T current version doesn't check or use them.

