### PR TITLE
Support for the Content-Type request header.

### DIFF
--- a/gobench.go
+++ b/gobench.go
@@ -301,6 +301,7 @@ func client(configuration *Configuration, result *Result, done *sync.WaitGroup) 
 			} else if len(configuration.postData) > 0 {
 				req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 			}
+
 			resp, err := myclient.Do(req)
 			result.requests++
 

--- a/gobench.go
+++ b/gobench.go
@@ -30,16 +30,18 @@ var (
 	writeTimeout     int
 	readTimeout      int
 	authHeader       string
+	contentType      string
 )
 
 type Configuration struct {
-	urls       []string
-	method     string
-	postData   []byte
-	requests   int64
-	period     int64
-	keepAlive  bool
-	authHeader string
+	urls        []string
+	method      string
+	postData    []byte
+	requests    int64
+	period      int64
+	keepAlive   bool
+	authHeader  string
+	contentType string
 }
 
 type Result struct {
@@ -92,6 +94,7 @@ func init() {
 	flag.IntVar(&writeTimeout, "tw", 5000, "Write timeout (in milliseconds)")
 	flag.IntVar(&readTimeout, "tr", 5000, "Read timeout (in milliseconds)")
 	flag.StringVar(&authHeader, "auth", "", "Authorization header")
+	flag.StringVar(&contentType, "type", "", "Content-Type header")
 }
 
 func printResults(results map[int]*Result, startTime time.Time) {
@@ -177,12 +180,13 @@ func NewConfiguration() *Configuration {
 	}
 
 	configuration := &Configuration{
-		urls:       make([]string, 0),
-		method:     "GET",
-		postData:   nil,
-		keepAlive:  keepAlive,
-		requests:   int64((1 << 63) - 1),
-		authHeader: authHeader}
+		urls:        make([]string, 0),
+		method:      "GET",
+		postData:    nil,
+		keepAlive:   keepAlive,
+		requests:    int64((1 << 63) - 1),
+		authHeader:  authHeader,
+		contentType: contentType}
 
 	if period != -1 {
 		configuration.period = period
@@ -291,6 +295,12 @@ func client(configuration *Configuration, result *Result, done *sync.WaitGroup) 
 				req.Header.Add("Authorization", configuration.authHeader)
 			}
 
+			if len(configuration.contentType) > 0 {
+				req.Header.Add("Content-Type", contentType)
+
+			} else if len(configuration.postData) > 0 {
+				req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+			}
 			resp, err := myclient.Do(req)
 			result.requests++
 


### PR DESCRIPTION
Hi there!  I was trying out gobench and my target server was rejecting POST requests due to a bad Content-Type request header.  This was trivial to fix so I forked and added that support.  Please consider merging this in, as I am sure there are others who would need this feature.