### PR TITLE
Improved precision of printed results

### DIFF
--- a/gobench.go
+++ b/gobench.go
@@ -111,8 +111,8 @@ func printResults(results map[int]*Result, startTime time.Time) {
 		writeThroughput += result.writeThroughput
 	}
 
-	elapsed := int64(time.Since(startTime).Seconds())
-
+	elapsed := time.Since(startTime).Seconds()
+	
 	if elapsed == 0 {
 		elapsed = 1
 	}
@@ -122,10 +122,10 @@ func printResults(results map[int]*Result, startTime time.Time) {
 	fmt.Printf("Successful requests:            %10d hits\n", success)
 	fmt.Printf("Network failed:                 %10d hits\n", networkFailed)
 	fmt.Printf("Bad requests failed (!2xx):     %10d hits\n", badFailed)
-	fmt.Printf("Successful requests rate:       %10d hits/sec\n", success/elapsed)
-	fmt.Printf("Read throughput:                %10d bytes/sec\n", readThroughput/elapsed)
-	fmt.Printf("Write throughput:               %10d bytes/sec\n", writeThroughput/elapsed)
-	fmt.Printf("Test time:                      %10d sec\n", elapsed)
+	fmt.Printf("Successful requests rate:       %10.0f hits/sec\n", float64(success)/elapsed)
+	fmt.Printf("Read throughput:                %10.0f bytes/sec\n", float64(readThroughput)/elapsed)
+	fmt.Printf("Write throughput:               %10.0f bytes/sec\n", float64(writeThroughput)/elapsed)
+	fmt.Printf("Test time:                      %10.2f sec\n", elapsed)
 }
 
 func readLines(path string) (lines []string, err error) {


### PR DESCRIPTION
I improved the printed results to account for fractional second and millisecond timing. The rates are still displayed as integers but the elapsed time is now a float with 2 decimal places. Example:

```
gobench -c 10 -r 1000 -u http://localhost/

Dispatching 10 clients
Waiting for results...

Requests:                            10000 hits
Successful requests:                 10000 hits
Network failed:                          0 hits
Bad requests failed (!2xx):              0 hits
Successful requests rate:             6166 hits/sec
Read throughput:                   5821455 bytes/sec
Write throughput:                   703014 bytes/sec
Test time:                            1.62 sec
```