### PR TITLE
setting fasthttp MaxConnsPerHost to be equal to concurrency

### DIFF
--- a/gobench.go
+++ b/gobench.go
@@ -230,7 +230,7 @@ func NewConfiguration() *Configuration {
 
 	configuration.myClient.ReadTimeout = time.Duration(readTimeout) * time.Millisecond
 	configuration.myClient.WriteTimeout = time.Duration(writeTimeout) * time.Millisecond
-	configuration.myClient.MaxConnsPerHost = clients
+	configuration.myClient.MaxConnsPerHost = clients * 2
 	configuration.myClient.Dial = MyDialer()
 
 	return configuration

--- a/gobench.go
+++ b/gobench.go
@@ -230,7 +230,8 @@ func NewConfiguration() *Configuration {
 
 	configuration.myClient.ReadTimeout = time.Duration(readTimeout) * time.Millisecond
 	configuration.myClient.WriteTimeout = time.Duration(writeTimeout) * time.Millisecond
-	configuration.myClient.MaxConnsPerHost = clients * 2
+	configuration.myClient.MaxConnsPerHost = clients
+
 	configuration.myClient.Dial = MyDialer()
 
 	return configuration
@@ -278,6 +279,7 @@ func client(configuration *Configuration, result *Result, done *sync.WaitGroup) 
 			fasthttp.ReleaseResponse(resp)
 
 			if err != nil {
+				fmt.Println(err)
 				result.networkFailed++
 				continue
 			}

--- a/gobench.go
+++ b/gobench.go
@@ -230,6 +230,7 @@ func NewConfiguration() *Configuration {
 
 	configuration.myClient.ReadTimeout = time.Duration(readTimeout) * time.Millisecond
 	configuration.myClient.WriteTimeout = time.Duration(writeTimeout) * time.Millisecond
+	configuration.myClient.MaxConnsPerHost = clients
 	configuration.myClient.Dial = MyDialer()
 
 	return configuration


### PR DESCRIPTION
fasthttp has an internal default limit of 512 max connections per host. This causes network errors if you use a concurrency higher than 512. Made a change to set the fasthttp MaxConnsPerHost to be equal to the concurrency configured in the gobench execution.

Before:
```
$ gobench -c 750 -t 5 -u http://openresty/
Dispatching 750 clients
Waiting for results...
Requests:                          4842824 hits
Successful requests:                  5990 hits
Network failed:                    4836833 hits
Bad requests failed (!2xx):              0 hits
Successful requests rate:             1198 hits/sec
Read throughput:                   1435200 bytes/sec
Write throughput:                   105332 bytes/sec
Test time:                               5 sec
```

After:
```
$ ./gobench -c 750 -t 5 -u http://openresty/
Dispatching 750 clients
Waiting for results...
Requests:                            52296 hits
Successful requests:                 52296 hits
Network failed:                          0 hits
Bad requests failed (!2xx):              0 hits
Successful requests rate:            10459 hits/sec
Read throughput:                  11546956 bytes/sec
Write throughput:                   859345 bytes/sec
Test time:                               5 sec
```