### PR TITLE
Insecure skip verify

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,12 @@ Usage
 2. download gobench
     
     ```
-    GOPATH=/tmp/ go get github.com/valyala/fasthttp
-    GOPATH=/tmp/ go get github.com/cmpxchg16/gobench
+    mkdir -p $GOPATH/src
+    cd $GOPATH/src
+    git clone https://github.com/cmpxchg16/gobench
+    cd gobench
+    go get
+    go build
     ```
 
 3. run some http server on port 80


### PR DESCRIPTION
Added new parameter '-s' that allows skip of cert check for SSL.  

This can be an issue in development environments where the server being access does not have certs matching the URL.